### PR TITLE
[Issue-18] Added support for specifying which database is wanted as a feature

### DIFF
--- a/dbmigrate-lib/Cargo.toml
+++ b/dbmigrate-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbmigrate-lib"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Vincent Prouillet <vincent@wearewizards.io>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
@@ -12,10 +12,16 @@ keywords = ["database", "postgres", "migration", "sql", "mysql"]
 [dependencies]
 regex = "0.2"
 url = "1"
-postgres = { version = "0.14", features = ["with-native-tls"] }
-mysql = "9.0"
-rusqlite = "0.9"
+postgres = { version = "0.14", features = ["with-native-tls"], optional=true }
+mysql = { version="9.0", optional=true}
+rusqlite = { version="0.9", optional=true}
 error-chain = "0.10"
 
 [dev-dependencies]
 tempdir = "0.3.4"
+
+[features]
+default = ["postgres_support", "sqlite_support", "mysql_support"]
+postgres_support = ["postgres"]
+sqlite_support = ["rusqlite"]
+mysql_support = ["mysql"]

--- a/dbmigrate-lib/src/drivers/mod.rs
+++ b/dbmigrate-lib/src/drivers/mod.rs
@@ -3,8 +3,11 @@ use url::{Url};
 
 use errors::{Result, ResultExt};
 
+#[cfg(feature = "mysql_support")]
 mod mysql;
+#[cfg(feature = "postgres_support")]
 mod postgres;
+#[cfg(feature = "sqlite_support")]
 mod sqlite;
 
 
@@ -31,8 +34,11 @@ pub fn get_driver(url: &str) -> Result<Box<Driver>> {
         .chain_err(|| format!("Invalid URL: {}", url))?;
 
     match parsed_url.scheme() {
+        #[cfg(feature = "postgres_support")]
         "postgres" => postgres::Postgres::new(url).map(|d| Box::new(d) as Box<Driver>),
+        #[cfg(feature = "mysql_support")]
         "mysql" => mysql::Mysql::new(url).map(|d| Box::new(d) as Box<Driver>),
+        #[cfg(feature = "sqlite_support")]
         "sqlite" => sqlite::Sqlite::new(url).map(|d| Box::new(d) as Box<Driver>),
         _ => bail!("Invalid URL: {}", url)
     }

--- a/dbmigrate-lib/src/errors.rs
+++ b/dbmigrate-lib/src/errors.rs
@@ -1,12 +1,15 @@
+#[cfg(feature = "postgres_support")]
 use postgres_client;
+#[cfg(feature = "mysql_support")]
 use mysql_client;
+#[cfg(feature = "sqlite_support")]
 use sqlite_client;
 
 error_chain! {
     foreign_links {
         Io(::std::io::Error) #[doc = "Failed to created/read migration files"];
-        Postgres(postgres_client::error::ConnectError) #[doc = "Couldn't get connection to pg database"];
-        MySQL(mysql_client::Error) #[doc = "Any MySQL error"];
-        Sqlite(sqlite_client::Error) #[doc = "Any Sqlite error"];
+        Postgres(postgres_client::error::ConnectError) #[doc = "Couldn't get connection to pg database"] #[cfg(feature = "postgres_support")];
+        MySQL(mysql_client::Error) #[doc = "Any MySQL error"] #[cfg(feature = "mysql_support")];
+        Sqlite(sqlite_client::Error) #[doc = "Any Sqlite error"] #[cfg(feature = "sqlite_support")];
     }
 }

--- a/dbmigrate-lib/src/lib.rs
+++ b/dbmigrate-lib/src/lib.rs
@@ -7,8 +7,11 @@ extern crate tempdir;
 
 extern crate regex;
 extern crate url;
+#[cfg(feature = "postgres_support")]
 extern crate postgres as postgres_client;
+#[cfg(feature = "mysql_support")]
 extern crate mysql as mysql_client;
+#[cfg(feature = "sqlite_support")]
 extern crate rusqlite as sqlite_client;
 #[macro_use]
 extern crate error_chain;

--- a/dbmigrate/Cargo.toml
+++ b/dbmigrate/Cargo.toml
@@ -20,5 +20,12 @@ default-features = false
 features = [ "suggestions", "color" , "unstable"]
 
 [dependencies.dbmigrate-lib]
-# path = "../dbmigrate-lib"
-version = "0.1.0"
+version = "0.1.1"
+default-features = false
+path = "../dbmigrate-lib" # Should be able to remove this line after version 0.1.1 of dbmigrate-lib is on crates.io
+
+[features]
+default = ["postgres_support", "sqlite_support", "mysql_support"]
+postgres_support = ["dbmigrate-lib/postgres_support"]
+sqlite_support = ["dbmigrate-lib/sqlite_support"]
+mysql_support = ["dbmigrate-lib/mysql_support"]


### PR DESCRIPTION
This is in relation to issue https://github.com/Keats/dbmigrate/issues/18

I've been having trouble getting sqlite installed (unrelated OSX problem) so I wasn't able to fully test this out.  I have, however, verified it works correctly for postgres, so it *should* work for the sqlite and mysql.

I've been abled to build the dbmigrate utility with only postgres support and it operates correctly, and I've been able to include dbmigrate-lib in an application I'm working on and it too appropriately connects to and operates on a postregres database.  Before making this change, my application was unable to run due to a linking problem with sqlite.

Btw, I really like this application - it exactly fits the need I had.  Thanks for building and maintaining it!