### PR TITLE
Fix the application name: myapp -> dbmigrate

### DIFF
--- a/dbmigrate/src/main.rs
+++ b/dbmigrate/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
 fn run() -> Result<()> {
     dotenv::dotenv().ok();
 
-    let matches = clap_app!(myapp =>
+    let matches = clap_app!(dbmigrate =>
         (@setting SubcommandRequiredElseHelp)
         (version: &crate_version!()[..])
         (author: "Vincent Prouillet <vincent@wearewizards.io>")


### PR DESCRIPTION
Before this change, getting the version of the application returned
an application named "myapp".  After this change, the application is
named "dbmigrate".