### PR TITLE
Use postgres-native-tls crate instead of with-tls feature

### DIFF
--- a/dbmigrate-lib/Cargo.toml
+++ b/dbmigrate-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbmigrate-lib"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Vincent Prouillet <vincent@wearewizards.io>"]
 license = "MIT OR Apache-2.0"
 readme = "../README.md"
@@ -12,7 +12,8 @@ keywords = ["database", "postgres", "migration", "sql", "mysql"]
 [dependencies]
 regex = "0.2"
 url = "1"
-postgres = { version = "0.15", features = ["with-native-tls"], optional=true }
+postgres-native-tls = { version = "0.1.0", optional=true }
+postgres = { version = "0.15", optional=true }
 mysql = { version="12", optional=true}
 rusqlite = { version = "0.14.0", optional = true }
 error-chain = "0.11"
@@ -22,6 +23,6 @@ tempdir = "0.3.4"
 
 [features]
 default = ["postgres_support", "sqlite_support", "mysql_support"]
-postgres_support = ["postgres"]
+postgres_support = ["postgres", "postgres-native-tls"]
 sqlite_support = ["rusqlite"]
 mysql_support = ["mysql"]

--- a/dbmigrate-lib/src/drivers/postgres.rs
+++ b/dbmigrate-lib/src/drivers/postgres.rs
@@ -1,5 +1,5 @@
 use postgres_client::{Connection, TlsMode};
-use postgres_client::tls::native_tls::NativeTls;
+use postgres_native_tls::NativeTls;
 use url::Url;
 
 use super::Driver;

--- a/dbmigrate-lib/src/lib.rs
+++ b/dbmigrate-lib/src/lib.rs
@@ -9,6 +9,8 @@ extern crate regex;
 extern crate url;
 #[cfg(feature = "postgres_support")]
 extern crate postgres as postgres_client;
+#[cfg(feature = "postgres_support")]
+extern crate postgres_native_tls;
 #[cfg(feature = "mysql_support")]
 extern crate mysql as mysql_client;
 #[cfg(feature = "sqlite_support")]


### PR DESCRIPTION
Both dbmigrate and dbmigrate-lib build, and the latter's tests also pass. It also compiles in my project (so the error is gone).

Fixes #34 