### PR TITLE
Fix "Unable to detect OpenSSL version" on Linux with OpenSSL >= 1.0.1

### DIFF
--- a/dbmigrate-lib/Cargo.toml
+++ b/dbmigrate-lib/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["database", "postgres", "migration", "sql", "mysql"]
 regex = "1"
 url = "1"
 native-tls = { version = "0.2", optional = true }
-postgres-native-tls = { version = "0.3.0", optional = true }
-postgres = { version = "0.17.0", optional = true }
+postgres-native-tls = { version = "0.5.0", optional = true }
+postgres = { version = "0.19.0", optional = true }
 mysql = { version="12", optional = true}
 rusqlite = { version = "0.14.0", optional = true }
 error-chain = "0.11"

--- a/dbmigrate/src/cmd.rs
+++ b/dbmigrate/src/cmd.rs
@@ -47,7 +47,7 @@ pub fn create(migration_files: &Migrations, path: &Path, slug: &str) -> Result<(
 }
 
 
-pub fn status(driver: Box<Driver>, migration_files: &Migrations) -> Result<()> {
+pub fn status(mut driver: Box<dyn Driver>, migration_files: &Migrations) -> Result<()> {
     let current = driver.get_current_number();
     if current == 0 {
         print::success("No migration has been ran");
@@ -64,7 +64,7 @@ pub fn status(driver: Box<Driver>, migration_files: &Migrations) -> Result<()> {
 }
 
 
-pub fn up(driver: Box<Driver>, migration_files: &Migrations) -> Result<()> {
+pub fn up(mut driver: Box<dyn Driver>, migration_files: &Migrations) -> Result<()> {
     let current = driver.get_current_number();
     let max = migration_files.keys().max().unwrap();
     if current == *max {
@@ -81,7 +81,7 @@ pub fn up(driver: Box<Driver>, migration_files: &Migrations) -> Result<()> {
     Ok(())
 }
 
-pub fn down(driver: Box<Driver>, migration_files: &Migrations) -> Result<()> {
+pub fn down(mut driver: Box<dyn Driver>, migration_files: &Migrations) -> Result<()> {
     let current = driver.get_current_number();
     if current == 0 {
         print::success("No down migrations to run");
@@ -99,7 +99,7 @@ pub fn down(driver: Box<Driver>, migration_files: &Migrations) -> Result<()> {
     Ok(())
 }
 
-pub fn redo(driver: Box<Driver>, migration_files: &Migrations) -> Result<()> {
+pub fn redo(mut driver: Box<dyn Driver>, migration_files: &Migrations) -> Result<()> {
     let current = driver.get_current_number();
     if current == 0 {
         print::success("No migration to redo");
@@ -116,7 +116,7 @@ pub fn redo(driver: Box<Driver>, migration_files: &Migrations) -> Result<()> {
 }
 
 
-pub fn revert(driver: Box<Driver>, migration_files: &Migrations) -> Result<()> {
+pub fn revert(mut driver: Box<dyn Driver>, migration_files: &Migrations) -> Result<()> {
     let current = driver.get_current_number();
     if current == 0 {
         print::success("No migration to revert");


### PR DESCRIPTION
## Problem

Can't cargo install on Linux if your system has `OpenSSL >= 1.0.1`.

https://github.com/sfackler/rust-openssl/issues/987#issuecomment-419246104

Output from cargo install:

`cargo install dbmigrate --no-default-features --features postgres_support -f `

```
error: failed to run custom build command for `openssl v0.9.24`

Caused by:
  process didn't exit successfully: `/tmp/cargo-installrGQwtx/release/build/openssl-016ad41b75ca22b1/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'Unable to detect OpenSSL version', /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.9.24/build.rs:16:14
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Fix

Upgrade dependencies.

## Notes

If this is accepted I'll remove the `path = ...` dependency that I commented in and then squash the commits. 

Just using it temporarily since I'm currently `cargo install`ing from my fork.

---

Can we cut a new dbmigrate release if/when this is accepted?

## Versions

```
$ rustc -V
rustc 1.54.0 (a178d0322 2021-07-26)
ubuntu@ip-172-31-24-62:~/actions-runner$ cargo -V
cargo 1.54.0 (5ae8d74b3 2021-06-22)
```