### PR TITLE
Fix migration number collisions

### DIFF
--- a/dbmigrate-lib/src/drivers/postgres.rs
+++ b/dbmigrate-lib/src/drivers/postgres.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use native_tls::TlsConnector;
 use postgres_client::{Client, Config};
-use postgres_native_tls::{MakeTlsConnector};
+use postgres_native_tls::MakeTlsConnector;
 
 use super::Driver;
 use errors::{Result, ResultExt};
@@ -10,7 +10,7 @@ use errors::{Result, ResultExt};
 /// The PostgreSQL driver
 //#[derive(Debug)]
 pub struct Postgres {
-    client: Client
+    client: Client,
 }
 
 impl Postgres {
@@ -24,7 +24,7 @@ impl Postgres {
     }
     /// Create PostgreSQL driver using an existing client
     pub fn from_client(client: Client) -> Result<Postgres> {
-        let mut pg = Postgres { client: client };
+        let mut pg = Postgres { client };
         pg.ensure_migration_table_exists();
         Ok(pg)
     }
@@ -32,35 +32,49 @@ impl Postgres {
 
 impl Driver for Postgres {
     fn ensure_migration_table_exists(&mut self) {
-        self.client.simple_query("
+        self.client
+            .simple_query(
+                "
             CREATE TABLE IF NOT EXISTS __dbmigrate_table(id INTEGER, current INTEGER);
             INSERT INTO __dbmigrate_table (id, current)
             SELECT 1, 0
             WHERE NOT EXISTS(SELECT * FROM __dbmigrate_table WHERE id = 1);
-        ").unwrap();
+        ",
+            )
+            .unwrap();
     }
 
     fn remove_migration_table(&mut self) {
-        self.client.execute("DROP TABLE __dbmigrate_table;", &[]).unwrap();
+        self.client
+            .execute("DROP TABLE __dbmigrate_table;", &[])
+            .unwrap();
     }
 
     fn get_current_number(&mut self) -> i32 {
-        let stmt = self.client.prepare("
+        let stmt = self
+            .client
+            .prepare(
+                "
             SELECT current FROM __dbmigrate_table WHERE id = 1;
-        ").unwrap();
+        ",
+            )
+            .unwrap();
         let results = self.client.query(&stmt, &[]).unwrap();
         results.first().unwrap().get("current")
     }
 
     fn set_current_number(&mut self, number: i32) {
-        let stmt = self.client.prepare(
-            "UPDATE __dbmigrate_table SET current = $1 WHERE id = 1;"
-        ).unwrap();
+        let stmt = self
+            .client
+            .prepare("UPDATE __dbmigrate_table SET current = $1 WHERE id = 1;")
+            .unwrap();
         self.client.execute(&stmt, &[&number]).unwrap();
     }
 
     fn migrate(&mut self, migration: String, number: i32) -> Result<()> {
-        self.client.simple_query(&migration).chain_err(|| "Migration failed")?;
+        self.client
+            .simple_query(&migration)
+            .chain_err(|| "Migration failed")?;
         self.set_current_number(number);
         Ok(())
     }


### PR DESCRIPTION
This commit fixes a bug where if there were multiple migrations with the
same migration number, only one of the migrations would run.

Instead, we now return an error if we detect multiple migrations with
the same number.

So, a directory that looks like this will now lead to an error:

```
0001.first-migration.up.sql
0001.first-migration.down.sql
0002.janes-migration.up.sql
0002.janes-migration.down.sql
0002.robs-migration.up.sql
0002.robs-migration.down.sql
```

Closed https://github.com/Keats/dbmigrate/issues/47
